### PR TITLE
Fixes: 6400 Include Cyan as an option in ButtonColorChoices

### DIFF
--- a/netbox/utilities/choices.py
+++ b/netbox/utilities/choices.py
@@ -134,6 +134,7 @@ class ButtonColorChoices(ChoiceSet):
     """
     DEFAULT = 'default'
     BLUE = 'primary'
+    CYAN = 'info'
     GREY = 'secondary'
     GREEN = 'success'
     RED = 'danger'
@@ -143,6 +144,7 @@ class ButtonColorChoices(ChoiceSet):
     CHOICES = (
         (DEFAULT, 'Default'),
         (BLUE, 'Blue'),
+        (CYAN, 'Cyan'),        
         (GREY, 'Grey'),
         (GREEN, 'Green'),
         (RED, 'Red'),


### PR DESCRIPTION
By including Cyan, or info, as a Button Color Choice, plugins will be able to create import buttons which match the core components.


Fixes: #6400

